### PR TITLE
Allow hosting a server with just port

### DIFF
--- a/phantomjs/highcharts-convert.js
+++ b/phantomjs/highcharts-convert.js
@@ -592,7 +592,7 @@
 	startServer = function (host, port) {
 		var server = require('webserver').create();
 
-		server.listen(host + ':' + port,
+		server.listen(host ? host + ':' + port : parseInt(port),
 			function (request, response) {
 				var jsonStr = request.postRaw || request.post,
 					params,
@@ -644,7 +644,7 @@
 		}
 	}
 
-	if (args.host !== undefined && args.port !== undefined) {
+	if (args.host !== undefined && args.port !== undefined || args.port !== undefined) {
 		startServer(args.host, args.port);
 	} else {
 		// presume commandline usage


### PR DESCRIPTION
A small change to allow hosting a server with just a port:

<pre>
phantomjs highcharts-convert.js -port 3003
</pre>
