### PR TITLE
allow user to inject his own scripts

### DIFF
--- a/phantomjs/highcharts-convert.js
+++ b/phantomjs/highcharts-convert.js
@@ -590,6 +590,13 @@
 						}
 					}
 
+					// load user libraries
+					if (params.injectjs) {
+						params.injectjs.split(',').map(function (jsFile) {
+							page.injectJs(jsFile);
+						});
+					}
+
 					// load chart in page and return svg height and width
 					svg = page.evaluate(createChart, constr, input, globalOptions, dataOptions, customCode, outType, callback, messages);
 

--- a/phantomjs/readme.md
+++ b/phantomjs/readme.md
@@ -9,7 +9,7 @@ For example highcharts.js or highstock.js and don't forget modules like gauge.js
 You need to install PhantomJS, a headless browser based on WebKit.
 For installation details, see http://phantomjs.org/download.html
 
-**note** 
+**note**
 The Highcharts files are subjected to the Highcharts License.
 #Example usage#
 ####Command line
@@ -40,6 +40,10 @@ The Highcharts files are subjected to the Highcharts License.
 	        'stroke-width' : 1
 	     }).add();
 	}
+
+**-injectjs:** Filename of extra script to inject in the page before rendering the chart (or comma-separated list of filenames):
+
+    phantomjs highcharts-convert.js -infile options1.json -outfile chart1.png -injectjs /my/own/jquery.js,/my/own/highcharts.js,/my/own/constants.js
 
 **-host** The hostname PhantomJS is listening to for POST-requests. If this parameter is specified, phantomjs startsup as Http-server.
 


### PR DESCRIPTION
Hello.
I've been struggling for a few hours trying to have `phantomjs/highcharts-convert.js` inject my own scripts. The rationale for this would be, for example:
- to tell `highcharts-convert.js` where to load Jquery or Highcharts,
- to tell `highcharts-convert.js` where to find constants that may have been passed in `-infile char.json` (in this scenario, my JSON file is not a pure JSON file, it has references to constants and callbacks such as tick positions or axis formatters, which are defined in a script I need to inject).

All of this could be done by manually overwriting:

```
    var config = {
            /* define locations of mandatory javascript files.
             * Depending on purchased license change the HIGHCHARTS property to
             * highcharts.js or highstock.js
             */
            files: {
                highcharts: {
```

but I'm trying to leave any vendor scripts pristine.
This PR allows the user to pass the paths to the scripts to inject.

Thanks 
