### PR TITLE
New param 'options' for json instead of infile

### DIFF
--- a/phantomjs/highcharts-convert.js
+++ b/phantomjs/highcharts-convert.js
@@ -613,7 +613,11 @@
 		if (params.length < 1) {
 			exit('Error: Insufficient parameters');
 		} else {
-			input = params.infile;
+		    	if (params.infile === undefined || params.infile.length === 0) {
+				input = params.options;
+			} else {
+				input = params.infile;
+			}
 			output = params.outfile;
 
 			if (output !== undefined) {


### PR DESCRIPTION
Allows 'options' input as json string instead of giving a file name.

For example in C# you can now create an anonymous options object and pass it serialized via phantomJs.
