### PR TITLE
Created a  fix for #19:

### DIFF
--- a/java/highcharts-export/highcharts-export-convert/src/main/java/com/highcharts/export/server/Server.java
+++ b/java/highcharts-export/highcharts-export-convert/src/main/java/com/highcharts/export/server/Server.java
@@ -1,5 +1,10 @@
 package com.highcharts.export.server;
 
+import com.highcharts.export.converter.SVGConverterException;
+import com.highcharts.export.util.TempDir;
+import org.apache.commons.io.IOUtils;
+
+import javax.annotation.PreDestroy;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,13 +16,10 @@ import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Timer;
 import java.util.concurrent.TimeoutException;
-
-import org.apache.commons.io.IOUtils;
-
-import com.highcharts.export.converter.SVGConverterException;
-import com.highcharts.export.util.TempDir;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static java.io.File.separator;
 
 public class Server {
 	private Process process;
@@ -38,6 +40,11 @@ public class Server {
 		this.connectTimeout = connectTimeout;
 		this.readTimeout = readTimeout;
 		this.maxTimeout = maxTimeout;
+
+		if (script.isEmpty()) {
+			// use the bundled highcharts-convert.js script
+			script = TempDir.getPhantomJsDir().toAbsolutePath().toString() + separator + "highcharts-convert.js";
+		}
 
 		try {
 			ArrayList<String> commands = new ArrayList<>();
@@ -166,5 +173,20 @@ public class Server {
 	@Override
 	public String toString() {
 		return this.getClass().getName() + "listening to port: " + port;
+	}
+
+	@PreDestroy
+	public void destroy() {
+		if (process != null) {
+			logger.log(Level.WARNING, "Shutting down PhantomJS instance, kill process directly, {0}", this.toString());
+			try {
+				process.getErrorStream().close();
+				process.getInputStream().close();
+				process.getOutputStream().close();
+			} catch (IOException e) {
+				logger.log(Level.WARNING, "Error while shutting down process: {0}", e.getMessage());
+			}
+			process.destroy();
+		}
 	}
 }

--- a/java/highcharts-export/highcharts-export-convert/src/main/resources/spring-convert.xml
+++ b/java/highcharts-export/highcharts-export-convert/src/main/resources/spring-convert.xml
@@ -37,4 +37,14 @@
 		<constructor-arg name="retentionTime" value="${retentionTime}"/>
 	</bean>
 
+	<bean id="server" class="com.highcharts.export.server.Server">
+		<constructor-arg name="exec" value="${exec}"/>
+		<constructor-arg name="script" value="${script}"/>
+		<constructor-arg name="host" value="${host}"/>
+		<constructor-arg name="port" value="#{serverObjectFactory.getAvailablePort()}"/>
+		<constructor-arg name="connectTimeout" value="${connectTimeout}"/>
+		<constructor-arg name="readTimeout" value="${readTimeout}"/>
+		<constructor-arg name="maxTimeout" value="${maxTimeout}"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
"Java export server fails after doing automatic re-deployment"
By making the Server into a bean, the PreDestroy is controllable.
Therefore, the phantomJS instance can be properly shut down when redeploying, and not refer to a different folder for writing than reading.
However, you for some reason have to refresh the browser after redeploy (did not work at all before).
