### PR TITLE
Added fix for #18, as suggested by @maxupp.

### DIFF
--- a/java/highcharts-export/highcharts-export-convert/src/main/resources/phantomjs/highcharts-convert.js
+++ b/java/highcharts-export/highcharts-export-convert/src/main/resources/phantomjs/highcharts-convert.js
@@ -678,8 +678,8 @@
 								resources = extend(resources, resourcesParam);
 							}
 						} catch(err) {
-							// Not parsing as JSON, try if we have the resources specfied by a comma separated list of filenames.
-							fileList = resources.split('\,');
+							// Not parsing as JSON, try if we have the resources specified by a comma separated list of filenames.
+							fileList = params.resources.split('\,');
 							resources = extend(resources, { files: fileList });
 						}
 					}


### PR DESCRIPTION
If the `resources` variable is not defined, and the resources param is a comma-separated list, the resources variable must be defined from `params.resources` instead of `resources`.
