### PR TITLE
Move imports to link-tag

### DIFF
--- a/phantomjs/highcharts-convert.js
+++ b/phantomjs/highcharts-convert.js
@@ -162,9 +162,10 @@
 				height: clipheight
 			};
 
+			// redefine the viewport
+			page.viewportSize = { width: clipwidth, height: clipheight };
+
 			if (outType === 'pdf') {
-				// redefine the viewport
-				page.viewportSize = { width: clipwidth, height: clipheight };
 
 				// simulate zooming to get the right zoomFactor. Using page.zoomFactor doesn't work anymore, see issue here https://github.com/ariya/phantomjs/issues/12685
 				page.evaluate(function (zoom) {

--- a/phantomjs/highcharts-convert.js
+++ b/phantomjs/highcharts-convert.js
@@ -101,8 +101,6 @@
 			callback,
 			output,
 			outType,
-			timer,
-			interval,
 			counter,
 			imagesLoaded = false;
 
@@ -177,9 +175,29 @@
 			}
 		}
 
+		function renderAndExit(svg) {
+			scaleAndClipPage(svg);
+			if (outType === 'pdf' || output !== undefined || !serverMode) {
+				if (output === undefined) {
+					// in case of pdf files
+					output = 'chart.' + outType;
+				}
+
+				if (config.tmpDir) {
+					// assume only output is a filename, not a path.
+					page.render(config.tmpDir + '/' + output);
+				} else {
+					page.render(output);
+				}
+
+				exit(output);
+			} else {
+				exit(page.renderBase64(outType));
+			}
+		}
+
 		function convert(svg) {
-			var base64,
-				interval,
+			var interval,
 				timer,
 				resourcesLoaded = false,
 				resource;
@@ -197,25 +215,7 @@
 				if (resourcesLoaded) {
 					clearTimeout(timer);
 					clearInterval(interval);
-					scaleAndClipPage(svg);
-					if (outType === 'pdf' || output !== undefined || !serverMode) {
-						if (output === undefined) {
-							// in case of pdf files
-							output = 'chart.' + outType;
-						}
-
-						if (config.tmpDir) {
-							// assume only output is a filename, not a path.
-							page.render(config.tmpDir + '/' + output);
-						} else {
-							page.render(output);
-						}
-
-						exit(output);
-					} else {
-						base64 = page.renderBase64(outType);
-						exit(base64);
-					}
+					renderAndExit(svg);
 				}
 			}, 50);
 
@@ -245,7 +245,9 @@
 		}
 
 		function renderSVG(svg) {
-			var svgFile;
+			var svgFile,
+				interval,
+				timer;
 			// From this point we have 'loaded' or 'created' a SVG
 
 			// Do we have to load images?


### PR DESCRIPTION
Fixes importing css with the `@import` css function, which is important in Highcharts styled mode (reported bug: #31).

The fix removes the @import-statements which are not supported in phantomjs, and puts the urls or paths in `<link rel="stylesheet" type="text/css" href="{importUrl}" />` inside `<head>`.

However, this does not fix importing css to SVGs, which need a different approach: https://www.w3.org/TR/SVG2/styling.html#LinkElement